### PR TITLE
Fix directory name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,13 @@ matrix:
     - os: osx
       env: CONFIG=Release TOOLCHAIN=libcxx
     - os: osx
-      env: CONFIG=Debug TOOLCHAIN=osx-10-11
+      env: CONFIG=Debug TOOLCHAIN=osx-10-12
     - os: osx
-      env: CONFIG=Release TOOLCHAIN=osx-10-11
+      env: CONFIG=Release TOOLCHAIN=osx-10-12
     - os: osx
-      env: CONFIG=Debug TOOLCHAIN=ios-nocodesign-9-3
+      env: CONFIG=Debug TOOLCHAIN=ios-nocodesign-10-3
     - os: osx
-      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-9-3
+      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-10-3
     - os: osx
       env: CONFIG=Debug TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
     - os: osx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.3) # IN_LIST
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.19.10.tar.gz"
-    SHA1 "73b5a5253b75d5ed79c89242c167ca1f94386621"
+    URL "https://github.com/ruslo/hunter/archive/v0.19.205.tar.gz"
+    SHA1 "9771566fa6d618202d8447122b3e7951505ed779"
 )
 
 project(gauze VERSION 0.2.1)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,16 +2,6 @@
 
 environment:
   matrix:
-    - TOOLCHAIN: "vs-10-2010"
-      CONFIG: "Release"
-    - TOOLCHAIN: "vs-10-2010"
-      CONFIG: "Debug"
-
-    - TOOLCHAIN: "vs-11-2012"
-      CONFIG: "Release"
-    - TOOLCHAIN: "vs-11-2012"
-      CONFIG: "Debug"
-
     - TOOLCHAIN: "vs-12-2013-win64"
       CONFIG: "Release"
     - TOOLCHAIN: "vs-12-2013-win64"

--- a/cmake/templates/AndroidTest.cmake.in
+++ b/cmake/templates/AndroidTest.cmake.in
@@ -142,7 +142,15 @@ foreach(arg ${app_arguments})
     if(NOT IS_DIRECTORY "${resource_dir}")
       message(FATAL_ERROR "Not a directory: ${resource_dir}")
     endif()
+
+    # Remove trailing '/' so we can get last component correctly
+    get_filename_component(resource_dir "${resource_dir}" ABSOLUTE)
+
     get_filename_component(res_name "${resource_dir}" NAME)
+    if("${res_name}" STREQUAL "")
+      message(FATAL_ERROR "Can't get directory name")
+    endif()
+
     set(res_path "${data_dir}/${res_name}")
     set(arguments "${arguments} \"${res_path}\"")
 

--- a/cmake/templates/iOSTest.cmake.in
+++ b/cmake/templates/iOSTest.cmake.in
@@ -160,7 +160,15 @@ foreach(arg ${app_arguments})
     if(NOT IS_DIRECTORY "${resource_dir}")
       message(FATAL_ERROR "Not a directory: ${resource_dir}")
     endif()
+
+    # Remove trailing '/' so we can get last component correctly
+    get_filename_component(resource_dir "${resource_dir}" ABSOLUTE)
+
     get_filename_component(res_name "${resource_dir}" NAME)
+    if("${res_name}" STREQUAL "")
+      message(FATAL_ERROR "Can't get directory name")
+    endif()
+
     set(res_path "@GAUZE_IOS_UPLOAD_ROOT@/${res_name}")
 
     # We need to keep GAUZE_RESOURCE_FILE for one more round of


### PR DESCRIPTION
If GAUZE_RESOURCE_DIR ends with '/' the 'get_filename_component' function will
return empty string as last component.