### PR TITLE
fix ios GAUZE_RESOURCE_{DIR,FILE}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Polly
 _logs/
 _builds/
 _install/
@@ -5,3 +6,6 @@ _install/
 docs/_build/
 docs/_spelling/
 docs/_venv/
+
+# Emacs
+*~

--- a/cmake/templates/AndroidTest.cmake.in
+++ b/cmake/templates/AndroidTest.cmake.in
@@ -76,8 +76,8 @@ foreach(arg ${app_arguments})
   string(
       REGEX
       REPLACE
-      "^\\$<GAUZE_RESOURCE_FILE:\(.*\)>$"
-      "\\1"
+      "^\(.*\)\\$<GAUZE_RESOURCE_FILE:\(.*\)>$"
+      "\\2"
       resource_file
       "${arg}"
   )
@@ -85,8 +85,8 @@ foreach(arg ${app_arguments})
   string(
       REGEX
       REPLACE
-      "^\\$<GAUZE_RESOURCE_DIR:\(.*\)>$"
-      "\\1"
+      "^\(.*\)\\$<GAUZE_RESOURCE_DIR:\(.*\)>$"
+      "\\2"
       resource_dir
       "${arg}"
   )
@@ -108,6 +108,17 @@ foreach(arg ${app_arguments})
   endif()
 
   if(is_resource_file)
+
+    # extract the flag:
+    string(
+        REGEX
+        REPLACE
+        "^\(.*\)\\$<GAUZE_RESOURCE_FILE:\(.*\)>$"
+        "\\1"
+        resource_flag
+        "${arg}"
+    )
+      
     message("Resource detected: '${resource_file}'")
     if(NOT IS_ABSOLUTE "${resource_file}")
       set(resource_file "@RESOURCE_DIR@/${resource_file}")
@@ -120,7 +131,7 @@ foreach(arg ${app_arguments})
     endif()
     get_filename_component(res_name "${resource_file}" NAME)
     set(res_path "${data_dir}/${res_name}")
-    set(arguments "${arguments} \"${res_path}\"")
+    set(arguments "${arguments} \"${resource_flag}${res_path}\"")
 
     message("Push resource to Android device:")
     message("  '${resource_file}'")
@@ -132,6 +143,17 @@ foreach(arg ${app_arguments})
       message(FATAL_ERROR "Command failed: ${cmd}")
     endif()
   elseif(is_resource_dir)
+
+    # extract the flag:
+    string(
+        REGEX
+        REPLACE
+        "^\(.*\)\\$<GAUZE_RESOURCE_DIR:\(.*\)>$"
+        "\\1"
+        resource_flag
+        "${arg}"
+    )
+    
     message("Directory with resources detected: '${resource_dir}'")
     if(NOT IS_ABSOLUTE "${resource_dir}")
       set(resource_dir "@RESOURCE_DIR@/${resource_dir}")
@@ -152,7 +174,7 @@ foreach(arg ${app_arguments})
     endif()
 
     set(res_path "${data_dir}/${res_name}")
-    set(arguments "${arguments} \"${res_path}\"")
+    set(arguments "${arguments} \"${resource_flag}${res_path}\"")    
 
     message("Remove destination directory: '${res_path}'")
     set(cmd ${adb_command} shell rm -rf \"${res_path}\")

--- a/cmake/templates/iOSTest.cmake.in
+++ b/cmake/templates/iOSTest.cmake.in
@@ -127,6 +127,16 @@ foreach(arg ${app_arguments})
   endif()
 
   if(is_resource_file)
+    # extract the flag:
+    string(
+        REGEX
+        REPLACE
+        "^\(.*\)\\$<GAUZE_RESOURCE_FILE:\(.*\)>$"
+        "\\1"
+        resource_flag
+        "${arg}"
+    )
+    
     message("Resource detected: '${resource_file}'")
     if(NOT IS_ABSOLUTE "${resource_file}")
       set(resource_file "@RESOURCE_DIR@/${resource_file}")
@@ -142,7 +152,7 @@ foreach(arg ${app_arguments})
 
     # We need to keep GAUZE_RESOURCE_FILE for one more round of
     # expansion because we need runtime HOME variable (see 'gauze.cpp')
-    set(arguments "${arguments} \"\$<GAUZE_RESOURCE_FILE:${res_path}>\"")
+    set(arguments "${arguments} \"${resource_flag}\$<GAUZE_RESOURCE_FILE:${res_path}>\"")
 
     message("Push resource to iOS device (bundle-id '@BUNDLE_ID@'):")
     message("  '${resource_file}'")
@@ -150,6 +160,17 @@ foreach(arg ${app_arguments})
 
     run_cmd(${ios_deploy} --bundle_id "@BUNDLE_ID@" --upload "${resource_file}" --to "${res_path}")
   elseif(is_resource_dir)
+
+    # extract the flag:
+    string(
+        REGEX
+        REPLACE
+        "^\(.*\)\\$<GAUZE_RESOURCE_DIR:\(.*\)>$"
+        "\\1"
+        resource_flag
+        "${arg}"
+    )
+    
     message("Directory with resources detected: '${resource_dir}'")
     if(NOT IS_ABSOLUTE "${resource_dir}")
       set(resource_dir "@RESOURCE_DIR@/${resource_dir}")
@@ -175,7 +196,7 @@ foreach(arg ${app_arguments})
     # expansion because we need runtime HOME variable (see 'gauze.cpp')
     # NOTE: GAUZE_RESOURCE_FILE used instead of GAUZE_RESOURCE_DIR
     # to simplify logic (see gauze.cpp)
-    set(arguments "${arguments} \"\$<GAUZE_RESOURCE_FILE:${res_path}>\"")
+    set(arguments "${arguments} \"${resource_flag}\$<GAUZE_RESOURCE_FILE:${res_path}>\"")
 
     message("Push directory to iOS device (bundle-id '@BUNDLE_ID@'):")
     message("  '${resource_dir}'")

--- a/test/gauze/gtest/CMakeLists.txt
+++ b/test/gauze/gtest/CMakeLists.txt
@@ -1,10 +1,23 @@
 hunter_add_package(GTest)
 find_package(GTest CONFIG REQUIRED)
 
-add_executable(gauze_gtest main.cpp)
-target_link_libraries(gauze_gtest PUBLIC GTest::gtest)
+hunter_add_package(cxxopts)
+find_package(cxxopts CONFIG REQUIRED)
 
-gauze_add_test(NAME gauze_gtest COMMAND gauze_gtest)
+add_executable(gauze_gtest main.cpp)
+target_link_libraries(gauze_gtest PUBLIC GTest::gtest cxxopts::cxxopts)
+
+set(data_dir "${CMAKE_CURRENT_LIST_DIR}/data")
+
+gauze_add_test(NAME gauze_gtest 
+  COMMAND gauze_gtest
+  "-a" # test short bool
+  "--aint=314159"
+  "--afloat=3.14159265359"
+  "--astring=3.14159265359"
+  "--afile=$<GAUZE_RESOURCE_FILE:${data_dir}/input.txt>"
+  "--adir=$<GAUZE_RESOURCE_DIR:${data_dir}>"
+)
 
 if(WIN32 OR CYGWIN)
   set(new_path "${GTEST_ROOT}/bin")

--- a/test/gauze/gtest/data/input.txt
+++ b/test/gauze/gtest/data/input.txt
@@ -1,0 +1,1 @@
+Gauze resource file

--- a/test/gauze/gtest/main.cpp
+++ b/test/gauze/gtest/main.cpp
@@ -8,6 +8,10 @@ int argc_;
 char** argv_;
 
 int gauze_main(int argc, char** argv) {
+  std::cout << "argc = " << argc << std::endl;
+  for (int i=0; i<argc; ++i) {
+      std::cout << "argv[" << i << "] = " << argv[i] << std::endl;
+  }
   argc_ = argc;
   argv_ = argv;
   ::testing::InitGoogleTest(&argc, argv);

--- a/test/gauze/gtest/main.cpp
+++ b/test/gauze/gtest/main.cpp
@@ -1,6 +1,15 @@
 #include <gtest/gtest.h> // TEST
 
+#include <cxxopts.hpp>
+
+#include <fstream>
+
+int argc_;
+char** argv_;
+
 int gauze_main(int argc, char** argv) {
+  argc_ = argc;
+  argv_ = argv;
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
@@ -12,4 +21,52 @@ TEST(gauze_gtest, arith) {
 TEST(gauze_gtest, boolean) {
   const bool a = true;
   ASSERT_TRUE(a);
+}
+
+static void check_file(const std::string &filename, const std::string &message) {
+    std::ifstream ifs(filename);
+    ASSERT_TRUE(ifs);
+    std::string line((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    ASSERT_EQ(line, message);
+}
+
+TEST(gauze_gtest, cli) {
+    
+    cxxopts::Options options("gauze-gtest", "Test command line parsing");
+
+    bool a = false;
+    int aint = 0;
+    float afloat = 0.f;
+    std::string astring;
+    std::string afile;
+    std::string adir;
+
+    bool b = false;
+    int bint = 0;
+    float bfloat = 0.f;
+    std::string bstring;
+    std::string bfile;
+    std::string bdir;
+
+    // clang-format off
+    options.add_options()
+        ("a,aval", "equals boolean", cxxopts::value<bool>(a))
+        ("aint", "equals integer", cxxopts::value<int>(aint))
+        ("afloat", "equals float", cxxopts::value<float>(afloat))
+        ("astring", "equals string", cxxopts::value<std::string>(astring))
+        ("afile", "equals filename", cxxopts::value<std::string>(afile))
+        ("adir", "equals directory", cxxopts::value<std::string>(adir))
+    ;
+    // clang-format on    
+    
+    options.parse(argc_, argv_);
+
+    static const std::string message = "Gauze resource file\n";
+    
+    ASSERT_EQ(a, true);
+    ASSERT_EQ(aint, 314159);
+    ASSERT_EQ(afloat, 3.14159265359f);
+    ASSERT_EQ(astring, "3.14159265359");
+    check_file(afile, message);
+    check_file(adir + "/input.txt", message);
 }


### PR DESCRIPTION
In cases where GAUZE_RESOURCE_FILE generator expression syntax was used on iOS and passed via a command line flag, gauze would incorrectly strip the flag:

In the example below we would remove the “—afile=“ part, so this:

```
"--afile=$<GAUZE_RESOURCE_FILE:${data_dir}/input.txt>"
```

would turn into this:
```
"$<GAUZE_RESOURCE_FILE:${data_dir}/input.txt>"
```

This would work only in cases where simple indexed parameter parsing  `std::string name=argv[1]` was used, and it would break command line parsers from working correctly.
We need to grab the flag separately and then apply it in the final stage where the full set of (expanded) arguments is passed to the iOS wrapper.

* test/gauze/gtest/main.cpp: store argc and argv and call cxxopts parser w/ gtests for expected inputs from ctest call
* add test/gauze/data/input.txt for testing both input file and directory generator expression expansion
* test/gauze/gtest/CMakeLists.txt: link cxopts and add some command line input tests
* cmake/templates/iOSTest.cmake.in: add extract flag (i.e., `—afile=` part of `—afile=$<GAUZE_RESOURCE_FILE:${data_dir}/input.txt>`) and apply it to the full command argument list after expansion
* ignore emacs temporary files